### PR TITLE
Replace dash with underscore.

### DIFF
--- a/napt-gradle/src/main/java/com/slapin/napt/task/CreateNaptTrigger.kt
+++ b/napt-gradle/src/main/java/com/slapin/napt/task/CreateNaptTrigger.kt
@@ -25,10 +25,15 @@ open class CreateNaptTrigger @Inject constructor(
     fun run() {
         val packagePrefix = packagePrefix.orNull?.let { "$it." } ?: ""
         val triggerCode = """
-                        package ${packagePrefix}${target.name};
+                        package ${getPackageName(packagePrefix, target)};
                         class NaptTrigger {
                         }
                     """.trimIndent()
         output.writeText(triggerCode)
+    }
+
+    private fun getPackageName(packagePrefix: String, project: Project): String {
+        val projectName = project.name.replace("-", "_")
+        return "${packagePrefix}${projectName}"
     }
 }


### PR DESCRIPTION
Module name may contain a dash but dash is not supported in Java
package name so we have to replace it with underscore.